### PR TITLE
feat: add relative and home dir path resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ go get -u github.com/hay-kot/xconf
 
 ## Features
 
-// TODO: Add Features
-
-## Examples
-
-// TODO: Add Examples
-
+- TOML Provider for sourcing configuration from a TOML File.
+- Read TOML path from cli args or environment variables.
+- Path Resolver for resolving relative paths in configuration files
+  - Resolves `./path` to be relative to the configuration file parent directory.
+  - Resolves `~/path` to be relative to the user's home directory.

--- a/cmd/ex/ex.toml
+++ b/cmd/ex/ex.toml
@@ -3,3 +3,5 @@ enable_config = true
 [nested]
 name = "My Name"
 number = 123
+user_path = "~/path/to/logs.log"
+rel_path = "./path/to/logs.log"

--- a/cmd/ex/main.go
+++ b/cmd/ex/main.go
@@ -11,8 +11,10 @@ import (
 )
 
 type Nested struct {
-	Name   string `toml:"name"   conf:"help:Name of the nested struct,notzero"`
-	Number int    `toml:"number"`
+	Name     string `toml:"name"      conf:"help:Name of the nested struct,notzero"`
+	Number   int    `toml:"number"`
+	UserPath string `toml:"user_path" xconf:"resolve"`
+	RelPath  string `toml:"rel_path"  xconf:"resolve"`
 }
 
 type Config struct {
@@ -46,6 +48,11 @@ func run() error {
 			return nil
 		}
 		return fmt.Errorf("parsing config: %w", err)
+	}
+
+	err = xconf.ResolvePaths(tomlProvider.FilePath(), cfg)
+	if err != nil {
+		return err
 	}
 
 	v, err := json.MarshalIndent(cfg, "", "  ")

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -49,4 +49,4 @@ tasks:
     env:
       EX_LOG_LEVEL: "from env"
     cmds:
-      - go run ./cmd/ex/main.go --toml-file ./cmd/ex/ex.toml
+      - go run ./cmd/ex/main.go --toml-file ./cmd/ex/ex.toml {{ .CLI_ARGS }}

--- a/xconf/path_resolver.go
+++ b/xconf/path_resolver.go
@@ -1,0 +1,94 @@
+package xconf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+)
+
+const (
+	tag        = "xconf"
+	tagResolve = "resolve"
+)
+
+// ResolvePaths walks the struct v and checks for the tag "conflib:resolve".
+// If the tag is found, it resolves the path relative to the configpath.
+// The configpath is the path to the configuration file. Absolute paths
+// are ignored.
+//
+// Example Resolutions:
+//   - './files.txt' -> '/path/to/configdir/files.txt'
+//   - '~/files.txt'  -> '/home/user/files.txt'
+func ResolvePaths(configpath string, v any) error {
+	// ensure configpath is absolute
+	if !filepath.IsAbs(configpath) {
+		// convert to absolute path
+		var err error
+		configpath, err = filepath.Abs(configpath)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	configdir := filepath.Dir(configpath)
+	return resolvePathsRecursive(configdir, reflect.ValueOf(v))
+}
+
+// resolvePathsRecursive is a helper function that recursively resolves paths
+func resolvePathsRecursive(configdir string, val reflect.Value) error {
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	// Ensure we're dealing with a struct
+	if val.Kind() != reflect.Struct {
+		return fmt.Errorf("expected struct, got %v", val.Kind())
+	}
+
+	// Iterate through the fields of the struct
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+		structField := val.Type().Field(i)
+
+		// Check if the field has the "conflib" tag with value "resolve"
+		if tagValue, ok := structField.Tag.Lookup(tag); ok && tagValue == tagResolve {
+			if field.Kind() == reflect.String && field.CanSet() {
+				path := field.String()
+
+				if path == "" {
+					continue
+				}
+
+				// If the path is not absolute, resolve it relative to the baseDir
+				if !filepath.IsAbs(path) {
+					if strings.HasPrefix(path, "~") {
+						homedir, err := os.UserHomeDir()
+						if err != nil {
+							return fmt.Errorf("get user home dir: %w", err)
+						}
+
+						path = strings.Replace(path, "~", homedir, 1)
+					} else {
+						path = filepath.Join(configdir, path)
+					}
+
+					field.SetString(path)
+				}
+			}
+		}
+
+		// Recursively resolve nested structs
+		if field.Kind() == reflect.Struct {
+			return resolvePathsRecursive(configdir, field)
+		}
+
+		// If the field is a pointer to a struct, resolve its paths recursively
+		if field.Kind() == reflect.Ptr && field.Elem().Kind() == reflect.Struct {
+			return resolvePathsRecursive(configdir, field)
+		}
+	}
+
+	return nil
+}

--- a/xconf/path_resolver_test.go
+++ b/xconf/path_resolver_test.go
@@ -1,0 +1,37 @@
+package xconf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_ResolvePaths(t *testing.T) {
+	type TConfig struct {
+		UserDir string `xconf:"resolve"`
+		RelPath string `xconf:"resolve"`
+	}
+
+	config := TConfig{
+		UserDir: "~/files.txt",
+		RelPath: "./files.txt",
+	}
+
+	err := ResolvePaths("/path/to/configdir/config.yaml", &config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("failed to get user home directory: %v", err)
+	}
+
+	if config.UserDir != filepath.Join(homedir, "files.txt") {
+		t.Fatalf("expected %s, got %s", filepath.Join(homedir, "files.txt"), config.UserDir)
+	}
+
+	if config.RelPath != "/path/to/configdir/files.txt" {
+		t.Fatalf("expected /path/to/configdir/files.txt, got %s", config.RelPath)
+	}
+}

--- a/xconf/toml.go
+++ b/xconf/toml.go
@@ -14,7 +14,8 @@ import (
 // executed to apply defaults and overrides. Fields that are not set to
 // their zero after the toml is parsed will have the defaults ignored.
 type TOML struct {
-	data []byte
+	filepath string
+	data     []byte
 }
 
 // WithFileSources accepts a list of flags and envs to search for the
@@ -48,7 +49,9 @@ func WithFileSources(args []string, flags []string, envs []string) (TOML, error)
 		return TOML{}, fmt.Errorf("open file: %w", err)
 	}
 
-	return WithReader(f), nil
+	t := WithReader(f)
+	t.filepath = filepath
+	return t, nil
 }
 
 func WithData(data []byte) TOML {
@@ -66,10 +69,16 @@ func WithReader(r io.Reader) TOML {
 }
 
 // Process performs the actual processing of the toml.
-func (y TOML) Process(prefix string, cfg interface{}) error {
-	err := toml.Unmarshal(y.data, cfg)
+func (t TOML) Process(prefix string, cfg interface{}) error {
+	err := toml.Unmarshal(t.data, cfg)
 	if err != nil {
 		return fmt.Errorf("unmarshal toml: %w", err)
 	}
 	return nil
+}
+
+// FilePath returns the file path of the toml file if provided. If no filepath
+// was found or provided, an empty string is returned.
+func (t TOML) FilePath() string {
+	return t.filepath
 }


### PR DESCRIPTION
## Purpose

When using configuration you often want to resolve paths relative to the config directory. This adds support for that as well as using the `~` alias for path resolution.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)